### PR TITLE
Fixed hero flag array: mislabelled InventoryID field and off-by-one guard

### DIFF
--- a/API/Core/GwAu3_Core_ArrayStructure.au3
+++ b/API/Core/GwAu3_Core_ArrayStructure.au3
@@ -290,7 +290,7 @@ Func Party_GetAllHeroFlags()
     Static $l_a_StructInfo = Memory_CreateArrayStructure( _
         "dword HeroID[0x0];" & _
         "dword AgentID[0x4];" & _
-        "dword Level[0x8];" & _
+        "dword InventoryID[0x8];" & _
         "dword Behavior[0xC];" & _
         "float FlagX[0x10];" & _
         "float FlagY[0x14];" & _
@@ -312,7 +312,7 @@ Func Party_GetHeroFlagByAgentID($a_i_AgentID)
     Static $l_a_StructInfo = Memory_CreateArrayStructure( _
         "dword HeroID[0x0];" & _
         "dword AgentID[0x4];" & _
-        "dword Level[0x8];" & _
+        "dword InventoryID[0x8];" & _
         "dword Behavior[0xC];" & _
         "float FlagX[0x10];" & _
         "float FlagY[0x14];" & _
@@ -334,7 +334,7 @@ Func Party_GetHeroFlagsWithBehavior($a_i_Behavior)
     Static $l_a_StructInfo = Memory_CreateArrayStructure( _
         "dword HeroID[0x0];" & _
         "dword AgentID[0x4];" & _
-        "dword Level[0x8];" & _
+        "dword InventoryID[0x8];" & _
         "dword Behavior[0xC];" & _
         "float FlagX[0x10];" & _
         "float FlagY[0x14];" & _

--- a/API/Modules/Data/GwAu3_Data_Party.au3
+++ b/API/Modules/Data/GwAu3_Data_Party.au3
@@ -341,7 +341,7 @@ EndFunc
 Func Party_GetHeroFlagInfo($a_i_HeroNumber = 1, $a_s_Info = "")
     Local $l_p_Ptr = World_GetWorldInfo("HeroFlagArray")
     Local $l_i_Size = World_GetWorldInfo("HeroFlagArraySize")
-    If $l_p_Ptr = 0 Or $a_i_HeroNumber < 1 Or $a_i_HeroNumber >= $l_i_Size Then Return 0
+    If $l_p_Ptr = 0 Or $a_i_HeroNumber < 1 Or $a_i_HeroNumber > $l_i_Size Then Return 0
 
     Local $l_i_HeroID = Party_GetMyPartyHeroInfo($a_i_HeroNumber, "AgentID")
     If $l_i_HeroID = 0 Then Return 0
@@ -359,7 +359,7 @@ Func Party_GetHeroFlagInfo($a_i_HeroNumber = 1, $a_s_Info = "")
             Return Memory_Read($l_p_HeroFlagPtr, "dword")
         Case "AgentID"
             Return Memory_Read($l_p_HeroFlagPtr + 0x4, "dword")
-        Case "Level"
+        Case "InventoryID"
             Return Memory_Read($l_p_HeroFlagPtr + 0x8, "dword")
         Case "Behavior"
             Return Memory_Read($l_p_HeroFlagPtr + 0xC, "dword")


### PR DESCRIPTION
Two unrelated issues in the hero flag array (WorldContext+0x584, 0x24-byte entries).

1. entry+0x8 was labelled "Level". It actually holds the hero's inventory ID:
   IUi::Game::ItemHelpGetInventoryFromAgent returns exactly *(entry + 8) for a
   hero, and in game the field returns 37/38/40 for heroes whose levels are
   20/18/20 - those values match their inventory IDs. Most likely a copy/paste
   from Party_GetHeroInfo(), where Level really is at entry+0x8 in a different
   table (0x9C-byte entries at +0x594). Renamed to "InventoryID" in
   Party_GetHeroFlagInfo() and in the three hero flag structures. No caller in
   the repository read the field under its old name.

2. Party_GetHeroFlagInfo() never returned the last hero: the guard compared a
   1-based hero number against a count with >=, so hero 2 of 2 and hero 4 of 4
   both returned 0. Changed to >.

Verified in game with 2 and 4 hero parties.