### PR TITLE
Added a native raycast against map scenery: Map_IsLineClear() and Map_QueryPropIntersection()

### DIFF
--- a/API/Constants/GwAu3_Const_Core.au3
+++ b/API/Constants/GwAu3_Const_Core.au3
@@ -207,6 +207,19 @@ Global $g_p_AcceptInvitation = DllStructGetPtr($g_d_AcceptInvitation)
 Global $g_bAutoStart = False  ; Flag for auto-start
 Global $g_s_MainCharName  = ""
 
+;Prop ray casting
+Global Const $GC_I_PROPRAY_MAX = 8            ; Rays carried by a single command
+Global Const $GC_I_PROPRAY_INPUT_SIZE = 28    ; Bytes per ray: origin[3] + dir[3] + dist
+Global Const $GC_I_PROPRAY_RESULT_SIZE = 12   ; Bytes per result: hit + distance + prop index
+Global Const $GC_I_PROPRAY_STATE_PENDING = 0  ; Command not processed yet
+Global Const $GC_I_PROPRAY_STATE_DONE = 1     ; Results available
+Global Const $GC_I_PROPRAY_STATE_SKIPPED = 2  ; No props loaded, native was never called
+Global Const $GC_F_PROPRAY_MIN_RANGE = 0.1    ; Below this the engine rejects the ray itself
+Global $g_p_PropRayResult       ; Pointer to the result block in GW memory
+Global $g_p_PropRayReady        ; Pointer to the completion flag in GW memory
+Global $g_d_PropRay = DllStructCreate('ptr;dword;float[56]')  ; Command struct: ptr + count + rays
+Global $g_p_PropRay = DllStructGetPtr($g_d_PropRay)
+
 ;EncString Decoding
 Global $g_p_DecodeInputPtr      ; Pointer to encoded string input buffer in GW memory
 Global $g_p_DecodeOutputPtr     ; Pointer to decoded string output buffer in GW memory

--- a/API/Core/GwAu3_Core.au3
+++ b/API/Core/GwAu3_Core.au3
@@ -98,6 +98,8 @@ Func Core_Initialize($a_v_GW, $a_b_ChangeTitle = True)
     Scanner_AddPattern('InvIdentifyAll', '558BEC83EC??A1????????33C58945FC8D45??50E8????????8B45??83C40483F8FF????????000053', 0x1, 'Func')
     Scanner_AddPattern('InvCanDepositAllMaterials', '558BEC83EC??5733FF33C0538945FC568D4D??C745??000000005150', 0x1, 'Func')
     Scanner_AddPattern('InvDepositAllMaterials', '558BEC83EC??A1????????33C58945FC53565733FF897D??EB068D9B', 0x1, 'Func')
+    ; Map patterns
+    Scanner_AddPattern('QueryPropIntersect', '558BEC83EC??535657E8????????8B40148B587C', 0x1, 'Func')
     ; Agent patterns
     Scanner_AddPattern('AgentBase', '8B0C9085C97419', -0x3, 'Ptr')
     Scanner_AddPattern('ChangeTarget', '3BDF0F95', -0x89, 'Func')
@@ -238,6 +240,7 @@ Func Core_Initialize($a_v_GW, $a_b_ChangeTitle = True)
     Memory_SetValue('InvIdentifyAll', Ptr(Scanner_GetScanResult('InvIdentifyAll', $g_ap_ScanResults, 'Func')))
     Memory_SetValue('InvCanDepositAllMaterials', Ptr(Scanner_GetScanResult('InvCanDepositAllMaterials', $g_ap_ScanResults, 'Func')))
     Memory_SetValue('InvDepositAllMaterials', Ptr(Scanner_GetScanResult('InvDepositAllMaterials', $g_ap_ScanResults, 'Func')))
+    Memory_SetValue('QueryPropIntersect', Ptr(Scanner_GetScanResult('QueryPropIntersect', $g_ap_ScanResults, 'Func')))
 	;Trader log
 	Log_Debug("BuyItemBase: " & Memory_GetValue('BuyItemBase'), "Initialize", $g_h_EditText)
 	Log_Debug("SalvageGlobal: " & Memory_GetValue('SalvageGlobal'), "Initialize", $g_h_EditText)
@@ -248,6 +251,7 @@ Func Core_Initialize($a_v_GW, $a_b_ChangeTitle = True)
 	Log_Debug("InvIdentifyAll: " & Memory_GetValue('InvIdentifyAll'), "Initialize", $g_h_EditText)
 	Log_Debug("InvCanDepositAllMaterials: " & Memory_GetValue('InvCanDepositAllMaterials'), "Initialize", $g_h_EditText)
 	Log_Debug("InvDepositAllMaterials: " & Memory_GetValue('InvDepositAllMaterials'), "Initialize", $g_h_EditText)
+	Log_Debug("QueryPropIntersect: " & Memory_GetValue('QueryPropIntersect'), "Initialize", $g_h_EditText)
 
 	;Agent
 	$g_p_AgentBase = Memory_Read(Scanner_GetScanResult('AgentBase', $g_ap_ScanResults, 'Ptr'))
@@ -494,6 +498,10 @@ Func Core_Initialize($a_v_GW, $a_b_ChangeTitle = True)
 	DllStructSetData($g_d_KickInvitedPlayer, 1, Memory_GetValue('CommandKickInvitedPlayer'))
 	DllStructSetData($g_d_RejectInvitation, 1, Memory_GetValue('CommandRejectInvitation'))
 	DllStructSetData($g_d_AcceptInvitation, 1, Memory_GetValue('CommandAcceptInvitation'))
+	;Prop ray casting
+	DllStructSetData($g_d_PropRay, 1, Memory_GetValue('CommandPropRay'))
+	$g_p_PropRayResult = Memory_GetValue('PropRayResult')
+	$g_p_PropRayReady = Memory_GetValue('PropRayReady')
 	;EncString
 	DllStructSetData($g_d_DecodeEncString, 1, Memory_GetValue('CommandDecodeEncString'))
 	$g_p_DecodeInputPtr = Memory_GetValue('DecodeInputPtr')

--- a/API/Core/GwAu3_Core_Assembler.au3
+++ b/API/Core/GwAu3_Core_Assembler.au3
@@ -1869,6 +1869,7 @@ Func Assembler_ModifyMemory()
 	Assembler_CreateItemCommands()
 	Assembler_CreateAgentCommands()
 	Assembler_CreateMapCommands()
+	Assembler_CreatePropRayCommand()
 	Assembler_CreateTradeCommands()
 	Assembler_CreateUICommands()
 	Assembler_CreatePartyCommands()
@@ -1923,6 +1924,9 @@ Func Assembler_CreateData()
 	_('InvIdentifyAllResult/4')
 	_('InvCanDepositAllMaterialsResult/4')
 	_('InvDepositAllMaterialsResult/4')
+	_('PropRayResult/96')        ; GC_I_PROPRAY_MAX results of 12 bytes
+	_('PropRayReady/4')          ; 0 = pending, 1 = results ready, 2 = skipped, no props
+
 	; EncString decoding buffers
 	_('DecodeReady/4')           ; Flag: 1 when decode is complete
 	_('DecodeInputPtr/256')      ; Input: encoded wchar string (max 128 wchars)
@@ -2458,6 +2462,70 @@ Func Assembler_CreateMapCommands()
 	_('push eax')
 	_('call Move')
 	_('pop eax')
+	_('ljmp CommandReturn')
+EndFunc
+
+; Ray cast against the map props: count at slot+4, then rays of 28 bytes from slot+8.
+Func Assembler_CreatePropRayCommand()
+	_('CommandPropRay:')
+	_('jmp PropRayStart')
+
+	; The map can unload between enqueue and execution, and the native asserts on null props
+	_('PropRaySkip:')
+	_('mov dword[PropRayReady],2')
+	_('ljmp CommandReturn')
+
+	_('PropRayStart:')
+	_('mov esi,eax')
+	_('mov eax,dword[BasePointer]')
+	_('test eax,eax')
+	_('jz PropRaySkip')
+	_('mov eax,dword[eax]')
+	_('test eax,eax')
+	_('jz PropRaySkip')
+	_('mov eax,dword[eax+18]')
+	_('test eax,eax')
+	_('jz PropRaySkip')
+	_('mov eax,dword[eax+14] -> 8B 40 14')
+	_('test eax,eax')
+	_('jz PropRaySkip')
+	_('mov eax,dword[eax+7C] -> 8B 40 7C')
+	_('test eax,eax')
+	_('jz PropRaySkip')
+	_('mov ebx,dword[eax+19C]')
+	_('test ebx,ebx')
+	_('jz PropRaySkip')
+
+	; ebx holds the loop counter: the native preserves ebx, esi and edi, but not ecx or edx
+	_('mov ebx,dword[esi+4] -> 8B 5E 04')
+	_('test ebx,ebx')
+	_('jz PropRaySkip')
+	_('cmp ebx,8')
+	_('ja PropRaySkip')
+
+	_('push PropRayResult')
+	_('pop edi')
+	_('add esi,8')
+
+	_('PropRayLoop:')
+	_('lea eax,dword[edi+8] -> 8D 47 08')
+	_('push eax')
+	_('lea eax,dword[esi+18] -> 8D 46 18')
+	_('push eax')
+	_('lea eax,dword[esi+C] -> 8D 46 0C')
+	_('push eax')
+	_('push esi')
+	_('call QueryPropIntersect')
+	_('add esp,10')
+	_('mov dword[edi],eax')
+	_('mov eax,dword[esi+18] -> 8B 46 18')
+	_('mov dword[edi+4],eax -> 89 47 04')
+	_('add esi,1C')
+	_('add edi,C')
+	_('dec ebx -> 4B')
+	_('jnz PropRayLoop')
+
+	_('mov dword[PropRayReady],1')
 	_('ljmp CommandReturn')
 EndFunc
 

--- a/API/Modules/Data/GwAu3_Data_MapContext.au3
+++ b/API/Modules/Data/GwAu3_Data_MapContext.au3
@@ -272,6 +272,99 @@ Func Map_GetPropModelFileId($a_p_PropPtr)
 	Return 0
 EndFunc   ;==>Map_GetPropModelFileId
 
+;~ Description: Casts up to $GC_I_PROPRAY_MAX segments against the map props in one command.
+;~ Rays is a 2D array [n][6] of X1, Y1, Z1, X2, Y2, Z2. Returns [n][4] of Hit, Distance in
+;~ game units, PropIndex and PropPtr, or 0 with @error 1 = arguments, 2 = no props, 3 = timeout.
+;~ Distance is negative, and a hit may be missed entirely, when a start point is inside a prop.
+Func Map_QueryPropIntersectionMulti($a_a_Rays, $a_i_Timeout = 250)
+	If Not IsArray($a_a_Rays) Or UBound($a_a_Rays, 0) <> 2 Then Return SetError(1, 0, 0)
+	If UBound($a_a_Rays, 2) < 6 Then Return SetError(1, 0, 0)
+
+	Local $l_i_Count = UBound($a_a_Rays, 1)
+	If $l_i_Count < 1 Or $l_i_Count > $GC_I_PROPRAY_MAX Then Return SetError(1, 0, 0)
+
+	; The native asserts on a null props context, and an assertion is fatal in retail
+	Local $l_p_PropsContext = Map_GetPropsContext()
+	If $l_p_PropsContext = 0 Then Return SetError(2, 0, 0)
+
+	; The direction must be a unit vector, the native asserts on it. The distance carries the
+	; range and is narrowed in place: read before being written, so it must never be zero.
+	For $i = 0 To $l_i_Count - 1
+		Local $l_f_DX = $a_a_Rays[$i][3] - $a_a_Rays[$i][0]
+		Local $l_f_DY = $a_a_Rays[$i][4] - $a_a_Rays[$i][1]
+		Local $l_f_DZ = $a_a_Rays[$i][5] - $a_a_Rays[$i][2]
+		Local $l_f_Length = Sqrt($l_f_DX * $l_f_DX + $l_f_DY * $l_f_DY + $l_f_DZ * $l_f_DZ)
+		If $l_f_Length < $GC_F_PROPRAY_MIN_RANGE Then Return SetError(1, 0, 0)
+
+		Local $l_i_Field = 1 + ($i * 7)
+		DllStructSetData($g_d_PropRay, 3, $a_a_Rays[$i][0], $l_i_Field)
+		DllStructSetData($g_d_PropRay, 3, $a_a_Rays[$i][1], $l_i_Field + 1)
+		DllStructSetData($g_d_PropRay, 3, $a_a_Rays[$i][2], $l_i_Field + 2)
+		DllStructSetData($g_d_PropRay, 3, $l_f_DX / $l_f_Length, $l_i_Field + 3)
+		DllStructSetData($g_d_PropRay, 3, $l_f_DY / $l_f_Length, $l_i_Field + 4)
+		DllStructSetData($g_d_PropRay, 3, $l_f_DZ / $l_f_Length, $l_i_Field + 5)
+		DllStructSetData($g_d_PropRay, 3, $l_f_Length, $l_i_Field + 6)
+	Next
+
+	DllStructSetData($g_d_PropRay, 2, $l_i_Count)
+	Memory_Write($g_p_PropRayReady, $GC_I_PROPRAY_STATE_PENDING, "dword")
+	Core_Enqueue($g_p_PropRay, 8 + ($l_i_Count * $GC_I_PROPRAY_INPUT_SIZE))
+
+	Local $l_i_Timer = TimerInit()
+	While TimerDiff($l_i_Timer) < $a_i_Timeout
+		Local $l_i_State = Memory_Read($g_p_PropRayReady, "dword")
+		If $l_i_State = $GC_I_PROPRAY_STATE_SKIPPED Then Return SetError(2, 0, 0)
+		If $l_i_State = $GC_I_PROPRAY_STATE_DONE Then
+			Local $l_p_PropArray = Memory_Read($l_p_PropsContext + 0x194, "ptr")
+			Local $l_a_Result[$l_i_Count][4]
+			For $i = 0 To $l_i_Count - 1
+				Local $l_p_Slot = $g_p_PropRayResult + ($i * $GC_I_PROPRAY_RESULT_SIZE)
+				Local $l_b_Hit = (Memory_Read($l_p_Slot, "dword") <> 0)
+				Local $l_i_Index = Memory_Read($l_p_Slot + 8, "dword")
+
+				$l_a_Result[$i][0] = $l_b_Hit
+				$l_a_Result[$i][1] = 0
+				$l_a_Result[$i][2] = -1
+				$l_a_Result[$i][3] = 0
+				If $l_b_Hit Then
+					; Already in game units: the direction sent to the native was normalised
+					$l_a_Result[$i][1] = Memory_Read($l_p_Slot + 4, "float")
+					$l_a_Result[$i][2] = $l_i_Index
+					; Same array and same indexing as Map_GetPropArray()
+					If $l_p_PropArray <> 0 Then
+						$l_a_Result[$i][3] = Memory_Read($l_p_PropArray + ($l_i_Index * 4), "ptr")
+					EndIf
+				EndIf
+			Next
+			Return $l_a_Result
+		EndIf
+		Sleep(4)
+	WEnd
+
+	Return SetError(3, 0, 0)
+EndFunc   ;==>Map_QueryPropIntersectionMulti
+
+;~ Description: Casts one segment against the map props.
+;~ Returns a 1D array [4] of Hit, Distance, PropIndex and PropPtr, or 0 with @error as above.
+Func Map_QueryPropIntersection($a_f_X1, $a_f_Y1, $a_f_Z1, $a_f_X2, $a_f_Y2, $a_f_Z2, $a_i_Timeout = 250)
+	Local $l_a_Rays[1][6] = [[$a_f_X1, $a_f_Y1, $a_f_Z1, $a_f_X2, $a_f_Y2, $a_f_Z2]]
+
+	Local $l_a_Result = Map_QueryPropIntersectionMulti($l_a_Rays, $a_i_Timeout)
+	If @error Then Return SetError(@error, 0, 0)
+
+	Local $l_a_Single[4] = [$l_a_Result[0][0], $l_a_Result[0][1], $l_a_Result[0][2], $l_a_Result[0][3]]
+	Return $l_a_Single
+EndFunc   ;==>Map_QueryPropIntersection
+
+;~ Description: Returns True when no prop stands between the two points.
+;~ A failed query returns False with @error set, so an unusable answer never reads as clear.
+Func Map_IsLineClear($a_f_X1, $a_f_Y1, $a_f_Z1, $a_f_X2, $a_f_Y2, $a_f_Z2, $a_i_Timeout = 250)
+	Local $l_a_Result = Map_QueryPropIntersection($a_f_X1, $a_f_Y1, $a_f_Z1, $a_f_X2, $a_f_Y2, $a_f_Z2, $a_i_Timeout)
+	If @error Then Return SetError(@error, 0, False)
+
+	Return Not $l_a_Result[0]
+EndFunc   ;==>Map_IsLineClear
+
 Func Map_GetNearestTravelPortal($a_f_X, $a_f_Y, $a_f_OffsetDistance = 50)
 	; Get all map props
 	Local $l_a_Props = Map_GetPropArray()


### PR DESCRIPTION
A script can now test whether scenery stands between two points.

Map_IsLineClear(x1, y1, z1, x2, y2, z2), boolean.
Map_QueryPropIntersection(...), hit, distance in game units, prop index and pointer. The index is directly valid in Map_GetPropArray().
Map_QueryPropIntersectionMulti(rays), up to 8 segments per command. One command costs one game frame, so 8 rays cost the same as 1.
The native asserts both on a missing props context and on the direction being a unit vector, and ErrorAssertion is fatal in retail. The direction is normalised inside the API, so callers only pass two points. The pointer chain is re-checked inside the ASM command and not only in AutoIt, because the map can unload between enqueue and execution.

Only static scenery is tested, not terrain, not agents, and a start point inside a prop returns an unreliable answer. Both noted in the function headers.