### PR TITLE
Refactor Quest_ functions: fix quest log state interpretation

### DIFF
--- a/API/Modules/Cmd/GwAu3_Cmd_Quest.au3
+++ b/API/Modules/Cmd/GwAu3_Cmd_Quest.au3
@@ -14,3 +14,8 @@ EndFunc   ;==>QuestReward
 Func Quest_AbandonQuest($a_i_QuestID)
     Return Core_SendPacket(0x8, $GC_I_HEADER_QUEST_ABANDON, $a_i_QuestID)
 EndFunc   ;==>AbandonQuest
+
+;~ Description: Request Description and Objective information.
+Func Quest_RequestInfos($a_i_QuestID)
+    Core_SendPacket(0x8, $GC_I_HEADER_QUEST_REQUEST_INFOS, $a_i_QuestID)
+EndFunc   ;==>Quest_RequestInfos

--- a/API/Modules/Cmd/GwAu3_Cmd_Quest.au3
+++ b/API/Modules/Cmd/GwAu3_Cmd_Quest.au3
@@ -14,11 +14,3 @@ EndFunc   ;==>QuestReward
 Func Quest_AbandonQuest($a_i_QuestID)
     Return Core_SendPacket(0x8, $GC_I_HEADER_QUEST_ABANDON, $a_i_QuestID)
 EndFunc   ;==>AbandonQuest
-
-Func Quest_ActiveQuest($a_i_QuestID)
-	If Not Quest_GetQuestInfo($a_i_QuestID, "IsCurrentQuest") Then Return Core_SendPacket(0xC, $GC_I_HEADER_QUEST_SET_ACTIVE, Quest_GetQuestInfo($a_i_QuestID, "IsAreaPrimary"))
-EndFunc
-
-Func Quest_RequestInfos($a_i_QuestID)
-	Return Core_SendPacket(0x8, $GC_I_HEADER_QUEST_REQUEST_INFOS, $a_i_QuestID)
-EndFunc

--- a/API/Modules/Data/GwAu3_Data_Quest.au3
+++ b/API/Modules/Data/GwAu3_Data_Quest.au3
@@ -25,7 +25,7 @@ Func Quest_GetQuestInfo($a_i_QuestID, $a_s_Info = "")
             Return True
         Case "LogState"
             Return Memory_Read($l_p_Ptr + 0x4, "long")
-        Case "IsSelected"
+        Case "HasInfo"
             Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x1) <> 0
         Case "IsCompleted"
             Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x2) <> 0

--- a/API/Modules/Data/GwAu3_Data_Quest.au3
+++ b/API/Modules/Data/GwAu3_Data_Quest.au3
@@ -11,39 +11,28 @@ Func Quest_GetQuestInfo($a_i_QuestID, $a_s_Info = "")
         Local $l_ap_QuestPtr = Memory_ReadPtr($g_p_BasePointer, $l_ai_OffsetQuestLog, "long")
         If $l_ap_QuestPtr[1] = $a_i_QuestID Then $l_p_Ptr = Ptr($l_ap_QuestPtr[0])
     Next
-    If $l_p_Ptr = 0 Then Return 0
+
+    If $l_p_Ptr = 0 Then
+        If $a_s_Info = "HasQuest" Then 
+            Return False
+        Else
+            Return 0
+        EndIf
+    EndIf
 
     Switch $a_s_Info
-        Case "HasQuest"
-            Return $l_p_Ptr <> 0
         Case "LogState"
             Return Memory_Read($l_p_Ptr + 0x4, "long")
+        Case "IsSelected"
+            Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x1) <> 0
         Case "IsCompleted"
-            Switch Memory_Read($l_p_Ptr + 0x4, "long")
-                Case 2, 3, 19, 32, 33, 34, 35, 79
-                    Return True
-                Case Else
-                    Return False
-            EndSwitch
-        Case "CanReward"
-            Switch Memory_Read($l_p_Ptr + 0x4, "long")
-                Case 32, 33
-                    Return True
-                Case Else
-                    Return False
-            EndSwitch
-        Case "IsIncomplete"
-            If Memory_Read($l_p_Ptr + 0x4, "long") = 1 Then Return True
-            Return False
+            Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x2) <> 0
         Case "IsCurrentQuest"
-            If Memory_Read($l_p_Ptr + 0x4, "long") = 0x10 Then Return True
-            Return False
-        Case "IsAreaPrimary"
-            If Memory_Read($l_p_Ptr + 0x4, "long") = 0x40 Then Return True
-            Return False
+            Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x10) <> 0
         Case "IsPrimary"
-            If Memory_Read($l_p_Ptr + 0x4, "long") = 0x20 Then Return True
-            Return False
+            Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x20) <> 0
+        Case "IsAreaPrimary"
+            Return BitAND(Memory_Read($l_p_Ptr + 0x4, "long"), 0x40) <> 0
 
         Case "Location"
             Local $l_p_LocationPtr = Memory_Read($l_p_Ptr + 0x8, "ptr")

--- a/API/Modules/Data/GwAu3_Data_Quest.au3
+++ b/API/Modules/Data/GwAu3_Data_Quest.au3
@@ -21,6 +21,8 @@ Func Quest_GetQuestInfo($a_i_QuestID, $a_s_Info = "")
     EndIf
 
     Switch $a_s_Info
+        Case "HasQuest"
+            Return True
         Case "LogState"
             Return Memory_Read($l_p_Ptr + 0x4, "long")
         Case "IsSelected"


### PR DESCRIPTION
The quest log state (ptr+0x4) is an additive/bitflag value, not a
set of singular values. Quest_GetQuestInfo previously checked for a
long list of specific combined values with no real understanding of
what they meant, causing incorrect results in several cases.

Changed Quest_GetQuestInfo to use BitAND against known flags instead:

- 0x1  HasInfo     - Information of this quest will be updated
- 0x2  IsCompleted    - reward is available to claim (not that it
                         has been claimed); replaces CanReward and
                         IsIncomplete, which were redundant/negated
                         versions of this check
- 0x10 IsCurrentQuest - previously misunderstood as "selected quest";
                         actually indicates the quest is only
                         available in the current instance (e.g. UW
                         quests)
- 0x20 IsPrimary       - simple primary quest
- 0x40 IsAreaPrimary   - overarching/area primary quest

0x4 and 0x8 are still unidentified.

**IMPORTANT:** Quest_GetQuestInfo now returns True/False when one calls Quest_GetQuestInfo($QuestID, "HasQuest") instead of True/0. Update your code!

Removed:
- Quest_ActiveQuest(): was non-functional, relied on the incorrect
  IsCurrentQuest/"selected" assumption. Also unnecessary, since quest
  log state can be read without actively selecting a quest.
- Quest_RequestInfos(): no identified use case.
- "CanReward" no longer exists
- "IsIncomplete" no longer exists