### PR TITLE
Fix: Stop a vanished target from killing the client

### DIFF
--- a/API/Constants/GwAu3_Const_Core.au3
+++ b/API/Constants/GwAu3_Const_Core.au3
@@ -219,6 +219,11 @@ Global Const $GC_I_PROPRAY_STATE_PENDING = 0  ; Command not processed yet
 Global Const $GC_I_PROPRAY_STATE_DONE = 1     ; Results available
 Global Const $GC_I_PROPRAY_STATE_SKIPPED = 2  ; No props loaded, native was never called
 Global Const $GC_F_PROPRAY_MIN_RANGE = 0.1    ; Below this the engine rejects the ray itself
+;Target guard diagnosis
+Global $g_p_TargetOrderCount    ; Pointer to the dequeued-order counter in GW memory
+Global $g_p_TargetRejectCount   ; Pointer to the rejected-order counter in GW memory
+Global $g_p_TargetRejectLast    ; Pointer to the last rejected agent id in GW memory
+
 Global $g_p_PropRayResult       ; Pointer to the result block in GW memory
 Global $g_p_PropRayReady        ; Pointer to the completion flag in GW memory
 Global $g_d_PropRay = DllStructCreate('ptr;dword;float[56]')  ; Command struct: ptr + count + rays

--- a/API/Core/GwAu3_Core.au3
+++ b/API/Core/GwAu3_Core.au3
@@ -518,6 +518,10 @@ Func Core_Initialize($a_v_GW, $a_b_ChangeTitle = True)
 	DllStructSetData($g_d_KickInvitedPlayer, 1, Memory_GetValue('CommandKickInvitedPlayer'))
 	DllStructSetData($g_d_RejectInvitation, 1, Memory_GetValue('CommandRejectInvitation'))
 	DllStructSetData($g_d_AcceptInvitation, 1, Memory_GetValue('CommandAcceptInvitation'))
+	;Target guard diagnosis
+	$g_p_TargetOrderCount = Memory_GetValue('TargetOrderCount')
+	$g_p_TargetRejectCount = Memory_GetValue('TargetRejectCount')
+	$g_p_TargetRejectLast = Memory_GetValue('TargetRejectLast')
 	;Prop ray casting
 	DllStructSetData($g_d_PropRay, 1, Memory_GetValue('CommandPropRay'))
 	$g_p_PropRayResult = Memory_GetValue('PropRayResult')

--- a/API/Core/GwAu3_Core_Assembler.au3
+++ b/API/Core/GwAu3_Core_Assembler.au3
@@ -1930,6 +1930,11 @@ Func Assembler_CreateData()
 	_('TradeSessResult/4')       ; Return value of the trade session native
 	_('TradeSessReady/4')        ; 0 = pending, 1 = value ready, 2 = skipped, no trade context
 
+	; Target guard diagnosis
+	_('TargetOrderCount/4')      ; Target orders actually dequeued by the game thread
+	_('TargetRejectCount/4')     ; Target orders refused since the ASM was injected
+	_('TargetRejectLast/4')      ; Last refused id, used to classify the real cause
+
 	; EncString decoding buffers
 	_('DecodeReady/4')           ; Flag: 1 when decode is complete
 	_('DecodeInputPtr/256')      ; Input: encoded wchar string (max 128 wchars)
@@ -2425,11 +2430,37 @@ Func Assembler_CreateItemCommands()
 EndFunc
 
 Func Assembler_CreateAgentCommands()
+	; The id is frozen on the AutoIt side and the native runs a frame later. If it no
+	; longer resolves, SelectionUpdate hits a fatal assertion, AvSelect.cpp(780), and
+	; kills the client. Replay ManagerFindAgent's exact contract in the
+	; game thread. Id 0 is NOT a stale id: SelectionUpdate tests manualAgentId before
+	; resolving it, so 0 clears the selection and must reach the native.
 	_('CommandChangeTarget:')
+	_('jmp ChangeTargetStart')
+
+	; Error exit on top, so every guard jump stays backwards and short
+	_('ChangeTargetSkip:')
+	_('inc dword[TargetRejectCount]')
+	_('mov dword[TargetRejectLast],ebx')
+	_('ljmp CommandReturn')
+
+	_('ChangeTargetStart:')
+	_('inc dword[TargetOrderCount]')  ; denominator: 0 rejects on 0 orders proves nothing
+	_('mov ebx,dword[eax+4]')
+	_('test ebx,ebx')
+	_('jz ChangeTargetCall')       ; 0 is a legitimate clear target, the native takes it
+	_('cmp ebx,dword[MaxAgents]')
+	_('jae ChangeTargetSkip')          ; unsigned, like the native's JC
+	_('mov esi,dword[AgentBase]')
+	_('lea esi,dword[esi+ebx*4]')
+	_('mov esi,dword[esi]')
+	_('test esi,esi')
+	_('jz ChangeTargetSkip')
+
+	_('ChangeTargetCall:')
 	_('xor edx,edx')
 	_('push edx')
-	_('mov eax,dword[eax+4]')
-	_('push eax')
+	_('push ebx')
 	_('call ChangeTarget')
 	_('add esp,8')
 	_('ljmp CommandReturn')

--- a/API/Modules/Cmd/GwAu3_Cmd_Agent.au3
+++ b/API/Modules/Cmd/GwAu3_Cmd_Agent.au3
@@ -3,7 +3,9 @@
 Func Agent_ChangeTarget($a_i_AgentID)
 	$a_i_AgentID = Agent_ConvertID($a_i_AgentID)
 
-    If $a_i_AgentID <= 0 Then
+    ; 0 is allowed on purpose: it is how the native clears the selection, and it is
+    ; what Agent_ClearTarget sends. Only a negative id is meaningless here.
+    If $a_i_AgentID < 0 Then
         Log_Error("Invalid agent ID: " & $a_i_AgentID, "AgentMod", $g_h_EditText)
         Return False
     EndIf
@@ -36,7 +38,9 @@ Func Agent_TargetNearestEnemy($a_f_MaxDistance = 1300)
     Local $l_i_MyID = Agent_GetMyID()
     Local $l_i_MaxAgents = Agent_GetMaxAgents()
 
-    For $i = 1 To $l_i_MaxAgents
+    ; MaxAgents is exclusive: ManagerFindAgent refuses id >= MaxAgents, so reading
+    ; that slot could hand Agent_ChangeTarget an id the native kills the client on.
+    For $i = 1 To $l_i_MaxAgents - 1
         ; Check if agent exists
         Local $l_p_Pointer = Agent_GetAgentPtr($i)
         If $l_p_Pointer = 0 Then ContinueLoop
@@ -72,7 +76,9 @@ Func Agent_TargetNearestAlly($a_f_MaxDistance = 1300, $a_b_ExcludeSelf = True)
     Local $l_i_MyID = Agent_GetMyID()
     Local $l_i_MaxAgents = Agent_GetMaxAgents()
 
-    For $l_i_Index = 1 To $l_i_MaxAgents
+    ; MaxAgents is exclusive: ManagerFindAgent refuses id >= MaxAgents, so reading
+    ; that slot could hand Agent_ChangeTarget an id the native kills the client on.
+    For $l_i_Index = 1 To $l_i_MaxAgents - 1
         ; Skip self if requested
         If $a_b_ExcludeSelf And $l_i_Index = $l_i_MyID Then ContinueLoop
 
@@ -111,7 +117,9 @@ Func Agent_TargetNearestAnimal($a_f_MaxDistance = 1300, $a_b_ExcludeSelf = True)
     Local $l_i_MyID = Agent_GetMyID()
     Local $l_i_MaxAgents = Agent_GetMaxAgents()
 
-    For $l_i_Index = 1 To $l_i_MaxAgents
+    ; MaxAgents is exclusive: ManagerFindAgent refuses id >= MaxAgents, so reading
+    ; that slot could hand Agent_ChangeTarget an id the native kills the client on.
+    For $l_i_Index = 1 To $l_i_MaxAgents - 1
         ; Skip self if requested
         If $a_b_ExcludeSelf And $l_i_Index = $l_i_MyID Then ContinueLoop
 

--- a/API/Modules/Data/GwAu3_Data_Agent.au3
+++ b/API/Modules/Data/GwAu3_Data_Agent.au3
@@ -45,6 +45,28 @@ Func Agent_GetAgentCopyBase()
     Return $g_p_AgentCopyBase
 EndFunc
 
+;~ Description: Target orders the game thread actually dequeued and ran the guard on.
+Func Agent_GetTargetOrderCount()
+    Return Memory_Read($g_p_TargetOrderCount, 'dword')
+EndFunc
+
+;~ Description: Target orders refused by the guard since the ASM was injected.
+Func Agent_GetTargetRejectCount()
+    Return Memory_Read($g_p_TargetRejectCount, 'dword')
+EndFunc
+
+;~ Description: Last agent id refused by the target guard.
+Func Agent_GetTargetRejectLast()
+    Return Memory_Read($g_p_TargetRejectLast, 'dword')
+EndFunc
+
+;~ Description: Resets the target guard diagnosis counters.
+Func Agent_ResetTargetRejectStats()
+    Memory_Write($g_p_TargetOrderCount, 0, 'dword')
+    Memory_Write($g_p_TargetRejectCount, 0, 'dword')
+    Memory_Write($g_p_TargetRejectLast, 0, 'dword')
+EndFunc
+
 Func Agent_GetLastTarget()
     Return $g_i_LastTargetID
 EndFunc


### PR DESCRIPTION
`Agent_ChangeTarget` freezes an agent id on the AutoIt side, but the native runs a frame later. If the agent dies, despawns, or the agent array shrinks in between, that id no longer resolves and the game hits a fatal assertion, the client dies instantly, with no error raised and nothing in the bot log to explain it.

The gap is structural. No amount of validation before enqueuing can close it, because the id can only be checked at the moment the native actually runs. So the guard goes there: inside the game command, right before the call. It replays exactly how the game resolves an id, both of its failure cases, and drops the order instead of taking the client down with it.

How often this bites depends entirely on what a script does. Retargeting dying enemies in crowded areas will run into it; a script that rarely changes target may never see it. In testing it was rare, a handful of refusals out of tens of thousands of orders, and fatal every single time it occurred.

Also fixed along the way:

- `Agent_ClearTarget()` works again. It sends id 0, which the API was rejecting — yet 0 is exactly how the game clears the selection.
- Three `Agent_TargetNearest*` loops read one slot past the end of the agent array.
- New counters to make the behaviour observable: orders processed, orders refused, and the last refused id.