### PR TITLE
Fix: decode the pet name instead of reading it as raw text

### DIFF
--- a/API/Modules/Data/GwAu3_Data_Party.au3
+++ b/API/Modules/Data/GwAu3_Data_Party.au3
@@ -280,13 +280,14 @@ Func Party_GetPetInfo($a_i_PetNumber = 1, $a_s_Info = "")
             Return Memory_Read($l_p_PetPtr + 0x4, "dword")
         Case "PetNamePtr"
             Return Memory_Read($l_p_PetPtr + 0x8, "ptr")
+        Case "PetNameEnc"
+            Local $l_p_NamePtr = Memory_Read($l_p_PetPtr + 0x8, "ptr")
+            If $l_p_NamePtr <= 0x10000 Then Return ""
+            Return Utils_DecodeEncString($l_p_NamePtr)
         Case "PetName"
             Local $l_p_NamePtr = Memory_Read($l_p_PetPtr + 0x8, "ptr")
-            If $l_p_NamePtr > 0x10000 Then
-                Return Memory_Read($l_p_NamePtr, "wchar[32]")
-            Else
-                Return "Unknown"
-            EndIf
+            If $l_p_NamePtr <= 0x10000 Then Return "Unknown"
+            Return Utils_DecodeEncStringAsync($l_p_NamePtr)
         Case "ModelFileID1"
             Return Memory_Read($l_p_PetPtr + 0xC, "dword")
         Case "ModelFileID2"


### PR DESCRIPTION
Party_GetPetInfo's PetName read record+0x8 as wchar[32]. That field is an encoded string, its first two wide chars are 0x0108 0x010A, so the raw read returned mojibake where the decoder returns Phoenix.

Route it through Utils_DecodeEncStringAsync, and add PetNameEnc for the numeric string id, matching the Name / NameEnc pair used everywhere else in the API. PetNamePtr unchanged.