### PR TITLE
Fix: replace Agent_GetNpcInfo's IsPet, which cannot work

### DIFF
--- a/API/Modules/Data/GwAu3_Data_Agent.au3
+++ b/API/Modules/Data/GwAu3_Data_Agent.au3
@@ -977,9 +977,6 @@ Func Agent_GetNpcInfo($a_i_ModelFileID = 0, $a_s_Info = "")
 		Case "IsMinion"
 			Local $flags = Memory_Read($l_p_AgentPtr + 0x10, "dword")
             Return BitAND($flags, 0x100) <> 0
-		Case "IsPet"
-			Local $flags = Memory_Read($l_p_AgentPtr + 0x10, "dword")
-            Return BitAND($flags, 0xD) <> 0
 		Case "Level"
             Return Memory_Read($l_p_AgentPtr + 0x1C, "dword")
 		Case "NameEnc"

--- a/API/Modules/Data/GwAu3_Data_Party.au3
+++ b/API/Modules/Data/GwAu3_Data_Party.au3
@@ -307,6 +307,32 @@ Func Party_GetPetInfo($a_i_PetNumber = 1, $a_s_Info = "")
             Return 0
     EndSwitch
 EndFunc
+
+;~ Description: Whether an agent is a charmed pet.
+Func Party_IsPet($a_v_AgentID)
+    Return Party_GetPetNumberByAgentID($a_v_AgentID) <> 0
+EndFunc
+
+;~ Description: The 1-based pet number for an agent, or 0 if that agent is not a pet.
+Func Party_GetPetNumberByAgentID($a_v_AgentID)
+    Local $l_i_AgentID = Agent_ConvertID($a_v_AgentID)
+    If $l_i_AgentID = 0 Then Return 0
+
+    Local $l_i_Count = World_GetWorldInfo("PetInfoArraySize")
+    If $l_i_Count <= 0 Then Return 0
+
+    For $i = 1 To $l_i_Count
+        If Party_GetPetInfo($i, "AgentID") = $l_i_AgentID Then Return $i
+    Next
+    Return 0
+EndFunc
+
+;~ Description: The owner of a pet agent, or 0 if that agent is not a pet.
+Func Party_GetPetOwnerByAgentID($a_v_AgentID)
+    Local $l_i_Number = Party_GetPetNumberByAgentID($a_v_AgentID)
+    If $l_i_Number = 0 Then Return 0
+    Return Party_GetPetInfo($l_i_Number, "OwnerAgentID")
+EndFunc
 #EndRegion Pet Related
 
 #Region Controlled Minion Related

--- a/Scripts/Tools/GwAu3_DevTools.au3
+++ b/Scripts/Tools/GwAu3_DevTools.au3
@@ -2198,7 +2198,7 @@ Func _GUI_Tab_DataFunctions()
             Log_Message("Scale: " & Agent_GetNpcInfo($modelID, "Scale") & ", Sex: " & Agent_GetNpcInfo($modelID, "Sex"), $c_UTILS_Msg_Type_Info, "DevTools")
             Log_Message("Primary: " & Agent_GetNpcInfo($modelID, "Primary") & ", Level: " & Agent_GetNpcInfo($modelID, "Level"), $c_UTILS_Msg_Type_Info, "DevTools")
             Log_Message("IsHenchman: " & Agent_GetNpcInfo($modelID, "IsHenchman") & ", IsHero: " & Agent_GetNpcInfo($modelID, "IsHero"), $c_UTILS_Msg_Type_Info, "DevTools")
-            Log_Message("IsSpirit: " & Agent_GetNpcInfo($modelID, "IsSpirit") & ", IsMinion: " & Agent_GetNpcInfo($modelID, "IsMinion") & ", IsPet: " & Agent_GetNpcInfo($modelID, "IsPet"), $c_UTILS_Msg_Type_Info, "DevTools")
+            Log_Message("IsSpirit: " & Agent_GetNpcInfo($modelID, "IsSpirit") & ", IsMinion: " & Agent_GetNpcInfo($modelID, "IsMinion") & ", IsPet: " & Party_IsPet($id), $c_UTILS_Msg_Type_Info, "DevTools")
         EndIf
 
         _ImGui_SameLine()


### PR DESCRIPTION
IsPet tested BitAND(flags, 0xD), three bits where every other flag in the family uses one, and returned true for all seven heroes of a party. There is no pet bit to fix it with: the client answers this question through the pet manager. CharCliPlayerCheckTargetType case 7 calls CPetMgr::GetPetData with the target's agent id and compares the record's owner against the controlled agent, and the only masks it applies to this field are 0x100 for a minion and 0x4000 for a spirit.

Remove the key and add Party_IsPet, Party_GetPetNumberByAgentID and Party_GetPetOwnerByAgentID, which read the array Party_GetPetInfo already uses. Validated in game: true on a charmed pet, false on the player, owner round-trips.